### PR TITLE
Make sure double-quotes in ALTER TABLE are not removed

### DIFF
--- a/lib/departure/alter_argument.rb
+++ b/lib/departure/alter_argument.rb
@@ -38,6 +38,7 @@ module Departure
       @parsed_statement ||= statement
         .gsub(ALTER_TABLE_REGEX, '')
         .gsub('`', '\\\`')
+        .gsub('"', '\\\"')
     end
   end
 end

--- a/spec/departure/alter_argument_spec.rb
+++ b/spec/departure/alter_argument_spec.rb
@@ -31,6 +31,18 @@ describe Departure::AlterArgument do
         )
       end
     end
+
+    context 'when the ALTER TABLE contains double quotes it escapes them' do
+      let(:statement) do
+        'ALTER TABLE `comments` CHANGE `some_id` `some_id` INT(11) DEFAULT NULL COMMENT \'a"quote\''
+      end
+
+      it do
+        is_expected.to(
+          eq('--alter "CHANGE \`some_id\` \`some_id\` INT(11) DEFAULT NULL COMMENT \'a\\"quote\'"')
+        )
+      end
+    end
   end
 
   describe '#table_name' do


### PR DESCRIPTION
They need to be included int the escaping, previously they would not be. This would make JSON specified in, for instance, column comments, invalid.